### PR TITLE
♻️ Update HA config modes to be built from availableModes

### DIFF
--- a/energysmartbridge/src/waterheater.js
+++ b/energysmartbridge/src/waterheater.js
@@ -215,7 +215,7 @@ export class WaterHeater {
             // Mode Config
             mode_state_topic: `energysmartbridge/${this.deviceId}/mode`,
             mode_state_template: this.generateModeMappingTemplate(false),
-            modes: ["eco", "electric", "off"], // list of supported modes
+            modes: this.availableModes.filter(mode => mode in MODE_MAPPING).map(mode => MODE_MAPPING[mode]), // dynamically built list of supported modes
 
             mode_command_topic: `energysmartbridge/${this.deviceId}/commands/mode`,
             mode_command_template: this.generateModeMappingTemplate(true),


### PR DESCRIPTION
The Heat Pump mode wasn't showing in HA for my water heater, dug in and found this list was hardcoded here

<details>
<summary>MQTT config from HA MQTT debug info</summary>

Topic: `homeassistant/water_heater/XXX/config`
Payload:
```yaml
mode_state_topic: energysmartbridge/XXX/mode
mode_state_template: >-
  {% set lookup =
  {"Efficiency":"heat_pump","Hybrid":"eco","Electric":"electric","Vacation":"off"}
  %}{{- lookup[value] -}}
mode_command_topic: energysmartbridge/XXX/commands/mode
mode_command_template: >-
  {% set lookup =
  {"heat_pump":"Efficiency","eco":"Hybrid","electric":"Electric","off":"Vacation"}
  %}{{- lookup[value] -}}
temperature_state_topic: energysmartbridge/XXX/set_point
temperature_command_topic: energysmartbridge/XXX/commands/temperature
current_temperature_topic: energysmartbridge/XXX/current_temperature
unique_id: XXX_water_heater
device:
  identifiers:
    - XXX
  serial_number: XXX
  name: Hot Water Heater XXX
modes:
  - eco
  - electric
  - 'off'
```
</details>